### PR TITLE
Feature/65 entrar app credenciales GitHub y Discord

### DIFF
--- a/decide/authentication/templates/master.html
+++ b/decide/authentication/templates/master.html
@@ -1,4 +1,5 @@
 {% load static %}
+{% load socialaccount %}
 
 <!DOCTYPE html>
 <html lang='es'>
@@ -36,10 +37,6 @@
                 <li><a href='/census/groups/import'>Importar grupo desde Excel.</a></li>
                 <li><a href='/census/groups/export'>Exportar miembros de un grupo a Excel.</a></li>
 
-                {% if user.is_superuser%}
-                <li><a href="/admin">Zona de administración</a></li>
-                {%else%}
-                {%endif%}
 
                 {% if user.is_authenticated %}
                 <li><a href="/census/operations">Operaciones entre grupos</a></li>
@@ -53,10 +50,17 @@
 
 
                 {%else %}
-                <li><a href="/authentication/registrarse">Regístrate</a></li>
-                <li><a href='/'>Autentícate con Twitter</a></li>
                 <li><a href="/authentication/iniciar_sesion">Iniciar sesión</a></li>
+                <li><a href="/authentication/registrarse">Regístrate</a></li>
+                <li><a href="{% provider_login_url 'github' %}">Autentícate con GitHub</a></li>
+
                 {% endif %}
+
+
+                {% if user.is_superuser%}
+                <li><a href="/admin">Zona de administración</a></li>
+                {%else%}
+                {%endif%}
             </ul>
 
         </div>

--- a/decide/authentication/templates/master.html
+++ b/decide/authentication/templates/master.html
@@ -42,6 +42,7 @@
                 {%endif%}
 
                 {% if user.is_authenticated %}
+                <li><a href="/census/operations">Operaciones entre grupos</a></li>
                 <li><a href="#">Sesión iniciada de {{user.username }}</a>
                     <div class="uk-navbar-dropdown">
                         <ul class="uk-nav uk-navbar-dropdown-nav">
@@ -49,10 +50,11 @@
                         </ul>
                     </div>
                 </li>
-                <li><a href="/census/operations">Operaciones entre grupos</a></li>
+
 
                 {%else %}
                 <li><a href="/authentication/registrarse">Regístrate</a></li>
+                <li><a href='/'>Autentícate con Twitter</a></li>
                 <li><a href="/authentication/iniciar_sesion">Iniciar sesión</a></li>
                 {% endif %}
             </ul>

--- a/decide/authentication/templates/master.html
+++ b/decide/authentication/templates/master.html
@@ -52,8 +52,16 @@
                 {%else %}
                 <li><a href="/authentication/iniciar_sesion">Iniciar sesión</a></li>
                 <li><a href="/authentication/registrarse">Regístrate</a></li>
-                <li><a href="{% provider_login_url 'github' %}">Autentícate con GitHub</a></li>
 
+
+                <li><a href="#">Autentícate con tus redes sociales</a>
+                    <div class="uk-navbar-dropdown">
+                        <ul class="uk-nav uk-navbar-dropdown-nav">
+                            <li><a href="{% provider_login_url 'github' %}">Autentícate con GitHub</a></li>
+                            <li><a href="{% provider_login_url 'discord' %}">Autentícate con Discord</a></li>
+                        </ul>
+                    </div>
+                </li>
                 {% endif %}
 
 

--- a/decide/authentication/tests.py
+++ b/decide/authentication/tests.py
@@ -8,7 +8,7 @@ from rest_framework.authtoken.models import Token
 from selenium import webdriver
 
 from base import mods
-from base.tests import BaseTestCase, SeleniumBaseTestCase
+from base.tests import SeleniumBaseTestCase
 from selenium.webdriver.common.by import By
 
 from django.contrib import auth
@@ -136,6 +136,7 @@ class AuthTestCase(APITestCase):
             sorted(list(response.json().keys())),
             ['token', 'user_pk']
         )
+
 
 class SeleniumTestCase(SeleniumBaseTestCase):
 
@@ -448,3 +449,22 @@ class RegistrarUsuarioTestCase(TestCase):
         self.assertEqual(response.status_code, HTTPStatus.OK)
         self.assertContains(response, "<h2>Formulario de registro en DECIDE</h2>", html=True)
 
+
+class RedesSocialesSeleniumTestCase(SeleniumBaseTestCase): #Imposible testear el correcto funcionamiento de la autenticación por redes sociales debido a diversos motivos más abajo explicados
+                                                            #Es lógico estar en esta situación puesto que es software de terceros y tienen sus propias políticas.
+                                                            #Se debe testear a mano.
+                                                            
+    #No se puede testear la autenticación con Discord porque no puedo crear un perfil de prueba en dicha apliación, ya que necesito un número de teléfono para verificar, y con mi móvil
+    #ya tengo mi cuenta personal que no pondría aquí por seguridad al dejar en bruto la contraseña. Testearé que la página donde introducir las credenciales se abre correctamente.
+    
+    def test_get_user_form_discord(self):
+        self.driver.get(f"{self.live_server_url}/accounts/discord/login/")
+        time.sleep(5)
+
+
+    #No se puede testear la autenticación con GitHub porque la página de inicio de sesión en esta plataforma bloquea la confirmación si se ejecuta bajo Selenium. 
+    #Testearé que la página donde introducir las credenciales se abre correctamente.
+    
+    def test_get_user_form_github(self):
+        self.driver.get(f"{self.live_server_url}/accounts/github/login/")
+        time.sleep(5)

--- a/decide/decide/settings.py
+++ b/decide/decide/settings.py
@@ -213,3 +213,6 @@ EMAIL_HOST = 'smtp.gmail.com'
 EMAIL_HOST_USER = 'decidepartchullo@gmail.com'  
 EMAIL_HOST_PASSWORD = 'decide1234%'  
 EMAIL_PORT = 587  
+
+SOCIAL_AUTH_TWITTER_KEY='uWQolqWb6mXT1xeeNaJfouVse'
+SOCIAL_AUTH_TWITTER_SECRET='QDxDHfOhG5RqggsEsYZj7Fsc6shgfG1T6D9r2QkT34yfeqmLCs'

--- a/decide/decide/settings.py
+++ b/decide/decide/settings.py
@@ -40,7 +40,12 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'scheduler.apps.SchedulerConfig',
-
+    'django.contrib.sites',
+    'allauth',
+    'allauth.account',
+    'allauth.socialaccount',
+    #"allauth.socialaccount.providers.twitter",
+    'allauth.socialaccount.providers.github',
     'corsheaders',
     'django_filters',
     'rest_framework',
@@ -48,6 +53,11 @@ INSTALLED_APPS = [
     'rest_framework_swagger',
     'gateway',
 ]
+
+SITE_ID = 1
+ACCOUNT_EMAIL_VERIFICATION = "none"
+LOGIN_REDIRECT_URL = "home"
+ACCOUNT_LOGOUT_ON_GET = True
 
 REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
@@ -58,7 +68,8 @@ REST_FRAMEWORK = {
 }
 
 AUTHENTICATION_BACKENDS = [
-    'base.backends.AuthBackend',
+    #'base.backends.AuthBackend',
+    "allauth.account.auth_backends.AuthenticationBackend",
 ]
 
 MODULES = [
@@ -74,7 +85,7 @@ MODULES = [
     'scheduler',
 ]
 
-BASEURL = 'http://localhost:8000'
+BASEURL = 'http://127.0.0.1:8000'
 
 MIDDLEWARE = [
     'django.middleware.security.SecurityMiddleware',
@@ -212,7 +223,4 @@ EMAIL_USE_TLS = True
 EMAIL_HOST = 'smtp.gmail.com'  
 EMAIL_HOST_USER = 'decidepartchullo@gmail.com'  
 EMAIL_HOST_PASSWORD = 'decide1234%'  
-EMAIL_PORT = 587  
-
-SOCIAL_AUTH_TWITTER_KEY='uWQolqWb6mXT1xeeNaJfouVse'
-SOCIAL_AUTH_TWITTER_SECRET='QDxDHfOhG5RqggsEsYZj7Fsc6shgfG1T6D9r2QkT34yfeqmLCs'
+EMAIL_PORT = 587

--- a/decide/decide/settings.py
+++ b/decide/decide/settings.py
@@ -224,3 +224,24 @@ EMAIL_HOST = 'smtp.gmail.com'
 EMAIL_HOST_USER = 'decidepartchullo@gmail.com'  
 EMAIL_HOST_PASSWORD = 'decide1234%'  
 EMAIL_PORT = 587
+
+
+#Pongo las credenciales de las APIs aquí a pesar de que es inseguro
+#para facilitar el trabajo de mis compañeros al ser un proyecto educativo. Estos datos no deberían aparecer aquí por seguridad
+SOCIALACCOUNT_PROVIDERS = {
+    'discord': {
+        'APP': {
+            'client_id': '926861240196816987',
+            'secret': 'yt6rWIVZP35OPAqGpNFxvkjpt9d27naG',
+            'key': ''
+        }
+    },
+    
+    'github': {
+        'APP': {
+            'client_id': '1058f9ffecc2528581d6',
+            'secret': '36d7a3339c7a19965d3cac1e860882d405fbf67a',
+            'key': ''
+        }
+    }
+}

--- a/decide/decide/settings.py
+++ b/decide/decide/settings.py
@@ -44,7 +44,7 @@ INSTALLED_APPS = [
     'allauth',
     'allauth.account',
     'allauth.socialaccount',
-    #"allauth.socialaccount.providers.twitter",
+    'allauth.socialaccount.providers.discord',
     'allauth.socialaccount.providers.github',
     'corsheaders',
     'django_filters',
@@ -68,7 +68,7 @@ REST_FRAMEWORK = {
 }
 
 AUTHENTICATION_BACKENDS = [
-    #'base.backends.AuthBackend',
+    'base.backends.AuthBackend',
     "allauth.account.auth_backends.AuthenticationBackend",
 ]
 

--- a/decide/decide/urls.py
+++ b/decide/decide/urls.py
@@ -25,7 +25,8 @@ urlpatterns = [
     path('admin/', admin.site.urls),
     path('doc/', schema_view),
     path('gateway/', include('gateway.urls')),
-    path('', vistasAuth.inicio)
+    path('', vistasAuth.inicio, name="home"),
+    path("accounts/", include("allauth.urls")),
 ]
 
 for module in settings.MODULES:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ APScheduler==3.5.3
 openpyxl==3.0.9
 gunicorn
 django-heroku
+django-allauth

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,4 +13,4 @@ APScheduler==3.5.3
 openpyxl==3.0.9
 gunicorn
 django-heroku
-django-allauth
+django-allauth==0.44.0


### PR DESCRIPTION
He terminado la implementación de la autenticación en la app mediante Discord y Github. Soy consciente de que la rama se llama "credenciales-Twitter", pues era la primera idea, pero al encontrarme con problemas externos ha sido imposible. También consideré Facebook pero acabé descartándola por los requisitos que solicita para usar su software. 

Se ha usado una aplicación llamada django-allauth para integrar Discord y GitHub, la cual se ha añadido a requirements.txt

En cuanto a los tests, ha sido imposible testear esta funcionalidad por diversos motivos, los cuales pero es lógico ya que se usa software de terceros, y en ambos casos o solicitan más datos o bloquean el acceso al ser test. Debe ser testeado manualmente.

Acceso por GitHub:
![Captura de pantalla de 2022-01-01 22-08-24](https://user-images.githubusercontent.com/72383530/147860213-03c9d1d0-cfd9-44e9-858b-0953f99d1fa4.png)

![Captura de pantalla de 2022-01-01 22-09-54](https://user-images.githubusercontent.com/72383530/147860232-86e669fd-985c-408f-a822-20c85cd753bc.png)

![imagen](https://user-images.githubusercontent.com/72383530/147860247-4676ce61-79c2-4b7d-8766-a3fff6ceb809.png)

Efectivamente se crea el usuario en la base de datos (decidepartchullo):
![imagen](https://user-images.githubusercontent.com/72383530/147860270-378b489f-468d-44ec-9f25-3380235b35fb.png)



Por Discord:
![imagen](https://user-images.githubusercontent.com/72383530/147860298-f63ee080-9623-435e-a43d-a00559f4409e.png)
![imagen](https://user-images.githubusercontent.com/72383530/147860309-0dd1e9ab-58ca-4630-9952-4a5eae97555a.png)
![imagen](https://user-images.githubusercontent.com/72383530/147860314-9deb2a23-5a36-4669-8f7f-f0fdd4bc6e0e.png)
![imagen](https://user-images.githubusercontent.com/72383530/147860315-e9611783-3e19-42eb-8113-13a2a6574213.png)

Se crea el usuario correctamente:
![imagen](https://user-images.githubusercontent.com/72383530/147860326-f16ba210-ba17-4074-894b-7750c6c6594d.png)

Pongo las credenciales de las APIs en settings.py a pesar de que es inseguro para facilitar el trabajo de mis compañeros al ser un proyecto educativo. Estos datos no deberían aparecer aquí por seguridad. Una vez se suba a heroku y se configure su base de datos, deberían ser eliminados

