### PR TITLE
Integrar funcionalidad #11 con #10 - Continuación

### DIFF
--- a/decide/authentication/templates/master.html
+++ b/decide/authentication/templates/master.html
@@ -33,11 +33,10 @@
                 </li>
 
 
-                <li><a href='/census/groups/import'>Importar grupo desde Excel.</a></li>
-                <li><a href='/census/groups/export'>Exportar miembros de un grupo a Excel.</a></li>
-
                 {% if user.is_superuser%}
                 <li><a href="/admin">Zona de administración</a></li>
+                <li><a href='/census/groups/import'>Importar grupo desde Excel.</a></li>
+                <li><a href='/census/groups/export'>Exportar miembros de un grupo a Excel.</a></li>
                 {%else%}
                 {%endif%}
 

--- a/decide/census/tests.py
+++ b/decide/census/tests.py
@@ -694,7 +694,7 @@ class ImportAndExportGroupSeleniumTestCase(SeleniumBaseTestCase):
         self.assertTrue(result)
 
 
-    # Prueba qué ocurre si se envía el formulario con el nombre vacío
+    # Prueba qué ocurre si se envía el formulario con el nombre vacío o solo
     def test_import_group_name_empty(self):
         self.login()
         self.driver.get(f"{self.live_server_url}/census/groups/import/")

--- a/decide/census/views.py
+++ b/decide/census/views.py
@@ -214,9 +214,11 @@ class ImportExportGroup(View):
 
     #@csrf_exempt
     @login_required(login_url='/authentication/iniciar_sesion')
-    @user_passes_test(lambda u: u.is_superuser)    
     def importGroup(request):
         form = importForm()
+
+        if not request.user.is_superuser:
+            return render(request, 'inicio.html', {'STATIC_URL':settings.STATIC_URL})
 
         if request.method == 'POST':
             form = importForm(request.POST, request.FILES)
@@ -255,9 +257,11 @@ class ImportExportGroup(View):
 
     #@csrf_exempt
     @login_required(login_url='/authentication/iniciar_sesion')
-    @user_passes_test(lambda u: u.is_superuser)    
     def exportGroup(request):
         form = exportForm()
+
+        if not request.user.is_superuser:
+            return render(request, 'inicio.html', {'STATIC_URL':settings.STATIC_URL})
 
         if request.method == 'POST':
             form = exportForm(request.POST, request.FILES)

--- a/decide/census/views.py
+++ b/decide/census/views.py
@@ -30,6 +30,7 @@ import os
 from django.core.files.storage import default_storage
 from django.core.files.base import ContentFile
 from django.views.decorators.csrf import csrf_exempt
+from django.contrib.auth.decorators import user_passes_test
 from django.contrib import messages
 from django.http import HttpResponse
 from django.shortcuts import render
@@ -212,6 +213,8 @@ class ImportExportGroup(View):
 
 
     #@csrf_exempt
+    @login_required(login_url='/authentication/iniciar_sesion')
+    @user_passes_test(lambda u: u.is_superuser)    
     def importGroup(request):
         form = importForm()
 
@@ -251,6 +254,8 @@ class ImportExportGroup(View):
             
 
     #@csrf_exempt
+    @login_required(login_url='/authentication/iniciar_sesion')
+    @user_passes_test(lambda u: u.is_superuser)    
     def exportGroup(request):
         form = exportForm()
 


### PR DESCRIPTION
Esta es una continuación de la pull request #71, debido a que faltaron commits a los que hacer push.

Para probar los cambios realizados:
1. Desplegar la aplicación en local e intentar acceder a "census/groups/import" y "census/groups/export" sin loguearse y ver que redirige a la página de login.
2. Intentar acceder a "census/groups/import" y "census/groups/export" con un usuario que no sea superuser y ver que no puede acceder a la funcionalidad.
3. Intentar acceder a "census/groups/import" y "census/groups/export" con un usuario que sí sea superuser y ver que sí puede acceder a la vista.
4. Ejecutar las pruebas del módulo census y comprobar que pasan todas.