### PR TITLE
Feature/100 configuracion docker vagrant

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -10,8 +10,9 @@ RUN pip install ipython
 
 WORKDIR /app
 
-RUN git clone https://github.com/decide-part-chullo/decide .
+RUN git clone https://github.com/decide-part-chullo/decide.git .
 RUN pip install -r requirements.txt
+COPY .env /app/decide/decide/decide
 
 WORKDIR /app/decide
 

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -14,7 +14,6 @@ services:
   web:
     restart: always
     container_name: decide_web
-    image: decide_web:latest
     build: .
     command: ash -c "python manage.py migrate && gunicorn -w 5 decide.wsgi --timeout=500 -b 0.0.0.0:5000"
     expose:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,8 +11,8 @@ django-nose==1.4.6
 jsonnet==0.12.1
 APScheduler==3.5.3
 openpyxl==3.0.9
-gunicorn
-django-heroku
+gunicorn==20.1.0
+django-heroku==0.3.1
 django-allauth==0.44.0
-django-environ
-selenium
+django-environ==0.8.1
+selenium==3.141.0

--- a/vagrant/files.yml
+++ b/vagrant/files.yml
@@ -19,3 +19,10 @@
   copy:
     src: files/settings.py
     dest: /home/decide/decide/decide/local_settings.py
+
+- name: .env
+  become: yes
+  become_user: decide
+  copy:
+    src: "files/.env"
+    dest: /home/decide/decide/decide/decide/.env


### PR DESCRIPTION
Se han añadido instrucciones necesarias para construir la imagen de decide y aprovisionar con Ansible la máquina virtual con el archivo .env. Construir la imagen de Docker tarda mucho, pero Vagrant funciona correctamente.